### PR TITLE
indent_size in .editorconfig removed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,4 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 indent_style = tab
-indent_size = 4
 charset = utf-8

--- a/parsers/dotnet/Taml.NET/Parser.cs
+++ b/parsers/dotnet/Taml.NET/Parser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -10,12 +10,14 @@ namespace TAML
 
 		private static readonly Regex _KeyValuePair = new Regex(@"(?<key>\S[^\t]*)\t+(?<value>\S[^\t]*)");
 
-		public static TamlDocument Parse(StreamReader rdr) {
+		public static TamlDocument Parse(StreamReader rdr)
+		{
 
 			rdr.BaseStream.Position = 0;
 			var outDoc = new TamlDocument();
 
-			while (!rdr.EndOfStream) {
+			while (!rdr.EndOfStream)
+			{
 				var line = rdr.ReadLine();
 				var captures = _KeyValuePair.Matches(line)[0].Groups;
 				outDoc.KeyValuePairs.Add(captures["key"].Value, new TamlValue(captures["value"].Value));

--- a/parsers/dotnet/Taml.NET/TamlDocument.cs
+++ b/parsers/dotnet/Taml.NET/TamlDocument.cs
@@ -2,9 +2,10 @@ using System.Collections.Generic;
 
 namespace TAML
 {
-	public class TamlDocument {
+	public class TamlDocument
+	{
 
-		public Dictionary<string,TamlValue> KeyValuePairs { get; set; } = new Dictionary<string, TamlValue>();
+		public Dictionary<string, TamlValue> KeyValuePairs { get; set; } = new Dictionary<string, TamlValue>();
 
 		// public string this[int index]
 		// {
@@ -14,20 +15,20 @@ namespace TAML
 
 	}
 
-  public class TamlValue
-  {
-    private string value;
+	public class TamlValue
+	{
+		private string value;
 
-    public TamlValue(string value)
-    {
-      this.value = value;
-    }
+		public TamlValue(string value)
+		{
+			this.value = value;
+		}
 
-    public override string ToString()
-    {
-      return value;
-    }
+		public override string ToString()
+		{
+			return value;
+		}
 
-  }
+	}
 
 }

--- a/parsers/dotnet/Test.Taml.NET/GivenSimplestTamlDoc/WhenParsingTheDoc.cs
+++ b/parsers/dotnet/Test.Taml.NET/GivenSimplestTamlDoc/WhenParsingTheDoc.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
+
 using Xunit;
 
 namespace TAML.Test.Taml.NET.GivenSimplestTamlDoc
@@ -8,11 +9,11 @@ namespace TAML.Test.Taml.NET.GivenSimplestTamlDoc
 	public class WhenParsingTheDoc
 	{
 
-    private readonly FileStream _Simple;
+		private readonly FileStream _Simple;
 
-    public WhenParsingTheDoc()
+		public WhenParsingTheDoc()
 		{
-			
+
 			_Simple = File.OpenRead("GivenSimplestTamlDoc/simple.taml");
 
 		}


### PR DESCRIPTION
I changed .editorconfig to not force a indent_size of 4 and found some spaces in the code that I changed into tabs