### PR TITLE
Rewrite of the Parser to also get the ComplexChildDocument Tests passing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,22 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
-end_of_line = lf
-insert_final_newline = true
-indent_style = tab
-charset = utf-8
+end_of_line                                            = lf
+insert_final_newline                                   = true
+indent_style                                           = tab
+charset                                                = utf-8
+
+# IDE0022: Use expression body for methods
+dotnet_diagnostic.IDE0022.severity                     = silent
+
+# IDE0021: Use expression body for constructors
+dotnet_diagnostic.IDE0021.severity                     = silent
+
+# IDE0023: Use expression body for operators
+dotnet_diagnostic.IDE0023.severity                     = silent
+
+# IDE0046: Convert to conditional expression
+dotnet_style_prefer_conditional_expression_over_return = false : warning
+
+# IDE0026: Use expression body for indexers
+dotnet_diagnostic.IDE0026.severity                     = silent

--- a/parsers/dotnet/Taml.NET/TamlDocument.cs
+++ b/parsers/dotnet/Taml.NET/TamlDocument.cs
@@ -7,6 +7,11 @@ namespace TAML
 
 		public List<TamlKeyValuePair> KeyValuePairs { get; set; } = new List<TamlKeyValuePair>();
 
+
+
+
+
+
 	}
 
 }

--- a/parsers/dotnet/Taml.NET/TamlDocument.cs
+++ b/parsers/dotnet/Taml.NET/TamlDocument.cs
@@ -7,11 +7,6 @@ namespace TAML
 
 		public List<TamlKeyValuePair> KeyValuePairs { get; set; } = new List<TamlKeyValuePair>();
 
-
-
-
-
-
 	}
 
 }

--- a/parsers/dotnet/Taml.NET/TamlExtensionMethods.cs
+++ b/parsers/dotnet/Taml.NET/TamlExtensionMethods.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace TAML
 {
-	public static class TamlExtensionMethods 
+	public static class TamlExtensionMethods
 	{
 
 		public static void Add(this IList<TamlKeyValuePair> list, string key, TamlValue value)
@@ -13,7 +13,7 @@ namespace TAML
 
 		}
 
-		public static TamlValue FindByKey(this IList<TamlKeyValuePair> list, string key)
+		public static TamlValue? FindByKey(this IList<TamlKeyValuePair> list, string key)
 		{
 
 			return list.FirstOrDefault(p => p.Key == key).Value;

--- a/parsers/dotnet/Taml.NET/TamlKeyValuePair.cs
+++ b/parsers/dotnet/Taml.NET/TamlKeyValuePair.cs
@@ -2,11 +2,7 @@ namespace TAML
 {
 	public class TamlKeyValuePair : TamlValue
 	{
-		public TamlKeyValuePair()
-		{
-		}
-
-		public TamlKeyValuePair(string key, TamlValue value)
+		public TamlKeyValuePair(string key, TamlValue? value)
 		{
 			this.Key = key;
 			this.Value = value;
@@ -14,14 +10,14 @@ namespace TAML
 
 		public string Key { get; set; }
 
-		public TamlValue Value { get; set; }
+		public TamlValue? Value { get; set; }
 
 		public override string ToString()
 		{
-			return $"{Key}: {Value.ToString()}";
+			return $"{Key}: {Value?.ToString()}";
 		}
 
-		public static implicit operator string(TamlKeyValuePair value) 
+		public static implicit operator string(TamlKeyValuePair value)
 		{
 			return value.ToString();
 		}

--- a/parsers/dotnet/Taml.NET/TamlValue.cs
+++ b/parsers/dotnet/Taml.NET/TamlValue.cs
@@ -1,22 +1,23 @@
-﻿namespace TAML
+namespace TAML
 {
 	public class TamlValue
 	{
-		private string value;
+		private readonly string _Value = string.Empty;
 
 		protected TamlValue() { }
 
 		public TamlValue(string value)
 		{
-			this.value = value;
+			this._Value = value;
 		}
 
 		public override string ToString()
 		{
-			return value;
+			return _Value;
 		}
 
-		public static implicit operator string(TamlValue value) {
+		public static implicit operator string(TamlValue value)
+		{
 
 			return value.ToString();
 

--- a/parsers/dotnet/Test.Taml.NET/GivenComplexChildDocument/WhenParsingSampleOne.cs
+++ b/parsers/dotnet/Test.Taml.NET/GivenComplexChildDocument/WhenParsingSampleOne.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+
 using TAML;
+
 using Xunit;
 
 namespace Test.Taml.NET.GivenComplexChildDocument
@@ -18,7 +20,7 @@ namespace Test.Taml.NET.GivenComplexChildDocument
 
 			var doc = Parser.Parse(base.Sample);
 
-			Assert.Equal(1, doc.KeyValuePairs.Count);
+			Assert.Single(doc.KeyValuePairs);
 			Assert.Equal("root", doc.KeyValuePairs.First().Key);
 
 		}

--- a/parsers/dotnet/Test.Taml.NET/GivenSimpleArray/WhenLoadingFile.cs
+++ b/parsers/dotnet/Test.Taml.NET/GivenSimpleArray/WhenLoadingFile.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Linq;
+
 using TAML;
+
 using Xunit;
 
 namespace Test.Taml.NET.GivenSimpleArray
@@ -22,7 +24,7 @@ namespace Test.Taml.NET.GivenSimpleArray
 
 			var result = Parser.Parse(Sample);
 
-			Assert.Equal(1, result.KeyValuePairs.Count);
+			Assert.Single(result.KeyValuePairs);
 			Assert.IsType<TamlArray>(result.KeyValuePairs.First().Value);
 
 		}


### PR DESCRIPTION
I have the parser rewritten the following way:

- read in all Lines and put them into `TamlKeyValuePair`s with the level they are intended (number of `\t` at the start of the line)
- in a second pass I first put all with 0 indentation into `TamlDocument.KeyValuePairs`
- if the indentation is larger as the current one I read in a parent value and replaced the Value of the KeyValuePair with a `TamlArray` and added the Values to the array. All subsequent values are addend to that parent.

All Tests are passing now.

I think I have seen some more opportunities for further unit tests. Some important code paths in my opinion are not covered by them.

Also this PR is based on the branch `feature_dotnet`

This also makes #26 not allowed because this parser doesn't allow inconstant indentation. There is also no unit test and sensible error handling for this case.

I also annotated some `Nullable`s