### PR TITLE
Implement MinVer to use proper Version Numbers

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,22 +8,21 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
+
     defaults:
       run:
         working-directory: parsers/dotnet
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.301
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.301
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,8 +1,8 @@
 name: publish to nuget
 on:
   release:
-    types: [ published ]
-        
+    types: [published]
+
 jobs:
   publish:
     name: build, pack & publish
@@ -17,10 +17,10 @@ jobs:
         with:
           # Filepath of the project to be packaged, relative to root of repository
           PROJECT_FILE_PATH: parsers/dotnet/Taml.NET/Taml.NET.csproj
-          
+
           # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
           VERSION_STATIC: ${{ github.event.release.tag_name }}
-          
+
           # Flag to toggle git tagging, enabled by default
           TAG_COMMIT: false
 

--- a/parsers/dotnet/Directory.Build.props
+++ b/parsers/dotnet/Directory.Build.props
@@ -2,9 +2,30 @@
 	<PropertyGroup>
 		<LangVersion>8</LangVersion>
 		<Nullable>enable</Nullable>
+
+		<!-- see https://github.com/adamralph/minver for more MinVer documentations -->
 		<MinVerVerbosity>normal</MinVerVerbosity>
 		<MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+
+		<!-- Overrides any calculated version when the ENV VAR VERSION_STATIC is set -->
+		<MinVerVersionOverride Condition=" '$(VERSION_STATIC)' != '' ">$(VERSION_STATIC)</MinVerVersionOverride>
 	</PropertyGroup>
+
+	<!-- Adds GITHUB_EVENT_NAME and GITHUB_SHA as BuildMetadata when this is not a build in the main branch -->
+	<PropertyGroup Condition=" '$(GITHUB_REF)' != 'main' ">
+		<MinVerBuildMetadata Condition=" '$(GITHUB_EVENT_NAME)' != '' ">$(GITHUB_EVENT_NAME.Replace('_','-')).</MinVerBuildMetadata>
+		<MinVerBuildMetadata>$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-')).</MinVerBuildMetadata>
+		<MinVerBuildMetadata Condition=" '$(GITHUB_SHA)' != '' ">$(MinVerBuildMetadata)$(GITHUB_SHA).</MinVerBuildMetadata>
+
+		<!-- some additional Env Vars that GitHub surfaces to us in an GitHub Action -->
+		<!--<MinVerBuildMetadata Condition=" '$(GITHUB_RUN_ID)' != '' ">$(MinVerBuildMetadata)$(GITHUB_RUN_ID).</MinVerBuildMetadata>
+		<MinVerBuildMetadata Condition=" '$(GITHUB_WORKFLOW)' != '' ">$(GITHUB_WORKFLOW)$(GITHUB_SHA).</MinVerBuildMetadata>
+		<MinVerBuildMetadata Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(MinVerBuildMetadata)$(GITHUB_RUN_NUMBER).</MinVerBuildMetadata>
+		<MinVerBuildMetadata Condition=" '$(GITHUB_ACTOR)' != '' ">$(MinVerBuildMetadata)$(GITHUB_ACTOR).</MinVerBuildMetadata>-->
+
+		<MinVerBuildMetadata>$(MinVerBuildMetadata.TrimEnd('.'))</MinVerBuildMetadata>
+	</PropertyGroup>
+
 
 	<ItemGroup>
 		<PackageReference Include="MinVer" Version="2.3.1">

--- a/parsers/dotnet/Directory.Build.props
+++ b/parsers/dotnet/Directory.Build.props
@@ -11,11 +11,14 @@
 		<MinVerVersionOverride Condition=" '$(VERSION_STATIC)' != '' ">$(VERSION_STATIC)</MinVerVersionOverride>
 	</PropertyGroup>
 
-	<!-- Adds GITHUB_EVENT_NAME and GITHUB_SHA as BuildMetadata when this is not a build in the main branch -->
-	<PropertyGroup Condition=" '$(GITHUB_REF)' != 'main' ">
+	<!--
+			Adds GITHUB_EVENT_NAME and GITHUB_SHA as BuildMetadata when this is not a build in the main branch and isn't a release
+			Attention: The Version Value has a size limit of 64 characters
+	-->
+	<PropertyGroup Condition=" '$(GITHUB_REF)' != 'refs/heads/main' And '$(GITHUB_EVENT_NAME)' != 'release'">
 		<MinVerBuildMetadata Condition=" '$(GITHUB_EVENT_NAME)' != '' ">$(GITHUB_EVENT_NAME.Replace('_','-')).</MinVerBuildMetadata>
-		<MinVerBuildMetadata>$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-').Replace("refs/heads/", "")).</MinVerBuildMetadata>
-		<MinVerBuildMetadata Condition=" '$(GITHUB_SHA)' != '' ">$(MinVerBuildMetadata)$(GITHUB_SHA).</MinVerBuildMetadata>
+		<MinVerBuildMetadata>$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-').Replace("refs/heads/", "").Replace("refs/tags/", "")).</MinVerBuildMetadata>
+		<MinVerBuildMetadata Condition=" '$(GITHUB_SHA)' != '' ">$(MinVerBuildMetadata)$(GITHUB_SHA.Remove(7)).</MinVerBuildMetadata>
 
 		<!-- some additional Env Vars that GitHub surfaces to us in an GitHub Action -->
 		<!--<MinVerBuildMetadata Condition=" '$(GITHUB_RUN_ID)' != '' ">$(MinVerBuildMetadata)$(GITHUB_RUN_ID).</MinVerBuildMetadata>

--- a/parsers/dotnet/Directory.Build.props
+++ b/parsers/dotnet/Directory.Build.props
@@ -14,7 +14,7 @@
 	<!-- Adds GITHUB_EVENT_NAME and GITHUB_SHA as BuildMetadata when this is not a build in the main branch -->
 	<PropertyGroup Condition=" '$(GITHUB_REF)' != 'main' ">
 		<MinVerBuildMetadata Condition=" '$(GITHUB_EVENT_NAME)' != '' ">$(GITHUB_EVENT_NAME.Replace('_','-')).</MinVerBuildMetadata>
-		<MinVerBuildMetadata>$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-')).</MinVerBuildMetadata>
+		<MinVerBuildMetadata>$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-').Replace("refs/heads/", "")).</MinVerBuildMetadata>
 		<MinVerBuildMetadata Condition=" '$(GITHUB_SHA)' != '' ">$(MinVerBuildMetadata)$(GITHUB_SHA).</MinVerBuildMetadata>
 
 		<!-- some additional Env Vars that GitHub surfaces to us in an GitHub Action -->

--- a/parsers/dotnet/Directory.Build.props
+++ b/parsers/dotnet/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+	<PropertyGroup>
+		<LangVersion>8</LangVersion>
+		<Nullable>enable</Nullable>
+		<MinVerVerbosity>normal</MinVerVerbosity>
+		<MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="MinVer" Version="2.3.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/parsers/dotnet/Directory.Build.props
+++ b/parsers/dotnet/Directory.Build.props
@@ -17,18 +17,17 @@
 	-->
 	<PropertyGroup Condition=" '$(GITHUB_REF)' != 'refs/heads/main' And '$(GITHUB_EVENT_NAME)' != 'release'">
 		<MinVerBuildMetadata Condition=" '$(GITHUB_EVENT_NAME)' != '' ">$(GITHUB_EVENT_NAME.Replace('_','-')).</MinVerBuildMetadata>
-		<MinVerBuildMetadata>$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-').Replace("refs/heads/", "").Replace("refs/tags/", "")).</MinVerBuildMetadata>
 		<MinVerBuildMetadata Condition=" '$(GITHUB_SHA)' != '' ">$(MinVerBuildMetadata)$(GITHUB_SHA.Remove(7)).</MinVerBuildMetadata>
 
 		<!-- some additional Env Vars that GitHub surfaces to us in an GitHub Action -->
-		<!--<MinVerBuildMetadata Condition=" '$(GITHUB_RUN_ID)' != '' ">$(MinVerBuildMetadata)$(GITHUB_RUN_ID).</MinVerBuildMetadata>
+		<!--<MinVerBuildMetadata Condition=" $(GITHUB_EVENT_NAME) != 'pull_request'">$(MinVerBuildMetadata)$(GITHUB_REF.Replace('_','-').Replace("refs/heads/", "").Replace("refs/tags/", "")).</MinVerBuildMetadata>
+		<MinVerBuildMetadata Condition=" '$(GITHUB_RUN_ID)' != '' ">$(MinVerBuildMetadata)$(GITHUB_RUN_ID).</MinVerBuildMetadata>
 		<MinVerBuildMetadata Condition=" '$(GITHUB_WORKFLOW)' != '' ">$(GITHUB_WORKFLOW)$(GITHUB_SHA).</MinVerBuildMetadata>
 		<MinVerBuildMetadata Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(MinVerBuildMetadata)$(GITHUB_RUN_NUMBER).</MinVerBuildMetadata>
 		<MinVerBuildMetadata Condition=" '$(GITHUB_ACTOR)' != '' ">$(MinVerBuildMetadata)$(GITHUB_ACTOR).</MinVerBuildMetadata>-->
 
 		<MinVerBuildMetadata>$(MinVerBuildMetadata.TrimEnd('.'))</MinVerBuildMetadata>
 	</PropertyGroup>
-
 
 	<ItemGroup>
 		<PackageReference Include="MinVer" Version="2.3.1">

--- a/parsers/dotnet/Taml.NET.sln
+++ b/parsers/dotnet/Taml.NET.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\..\.editorconfig = ..\..\.editorconfig
 		..\..\CODE-OF-CONDUCT.md = ..\..\CODE-OF-CONDUCT.md
 		..\..\CONTRIBUTING.md = ..\..\CONTRIBUTING.md
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Global

--- a/parsers/dotnet/Taml.NET/Taml.NET.csproj
+++ b/parsers/dotnet/Taml.NET/Taml.NET.csproj
@@ -1,22 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-	  <LangVersion>8.0</LangVersion>
-	<Nullable>enable</Nullable>
-	<PackageId>TAML</PackageId>
-	<Version>0.2.0</Version>
-	<Authors>Jeffrey T. Fritz and Friends</Authors>
-	<Company />
-	<Product></Product>
-	<Description>TAML Parser and interpreter for .NET</Description>
-	<Copyright>Copyright Jeffrey T. Fritz 2020</Copyright>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	<PackageProjectUrl>https://github.com/csharpfritz/TAML</PackageProjectUrl>
-	<RepositoryUrl>https://github.com/csharpfritz/TAML</RepositoryUrl>
-	<RepositoryType>GitHub</RepositoryType>
-	<PackageReleaseNotes>0.2 - First package release with basic parser</PackageReleaseNotes>
-	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<PackageId>TAML</PackageId>
+		<Version>0.2.0</Version>
+		<Authors>Jeffrey T. Fritz and Friends</Authors>
+		<Company />
+		<Product></Product>
+		<Description>TAML Parser and interpreter for .NET</Description>
+		<Copyright>Copyright Jeffrey T. Fritz 2020</Copyright>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/csharpfritz/TAML</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/csharpfritz/TAML</RepositoryUrl>
+		<RepositoryType>GitHub</RepositoryType>
+		<PackageReleaseNotes>0.2 - First package release with basic parser</PackageReleaseNotes>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	</PropertyGroup>
 
 </Project>

--- a/parsers/dotnet/Taml.NET/Taml.NET.csproj
+++ b/parsers/dotnet/Taml.NET/Taml.NET.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<PackageId>TAML</PackageId>
+		<PackageId>Stelzi79.TAML</PackageId>
 		<Version>0.2.0</Version>
 		<Authors>Jeffrey T. Fritz and Friends</Authors>
 		<Company />

--- a/parsers/dotnet/Taml.NET/Taml.NET.csproj
+++ b/parsers/dotnet/Taml.NET/Taml.NET.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<PackageId>Stelzi79.TAML</PackageId>
+		<PackageId>TAML</PackageId>
 		<Version>0.2.0</Version>
 		<Authors>Jeffrey T. Fritz and Friends</Authors>
 		<Company />

--- a/parsers/dotnet/Test.Taml.NET/Test.Taml.NET.csproj
+++ b/parsers/dotnet/Test.Taml.NET/Test.Taml.NET.csproj
@@ -1,51 +1,51 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="1.3.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Taml.NET\Taml.NET.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Taml.NET\Taml.NET.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="GivenChildArrays\childarrays.taml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="GivenComplexChildDocument\sample1.taml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="GivenMultipleRoots\sample1.taml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="GivenOnlyKeyValuePairs\simple.taml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="GivenSimpleArray\simple.taml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="GivenKeyValuePairsWithArray\sample.taml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="GivenKeyValuePairsWithArray\arrayfirst.taml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="GivenChildArrays\childarrays.taml">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="GivenComplexChildDocument\sample1.taml">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="GivenMultipleRoots\sample1.taml">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="GivenOnlyKeyValuePairs\simple.taml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="GivenSimpleArray\simple.taml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="GivenKeyValuePairsWithArray\sample.taml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="GivenKeyValuePairsWithArray\arrayfirst.taml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 
 </Project>


### PR DESCRIPTION
* updated Microsoft.NET.Test.Sdk to latest stable 16.7.1
* implemented MinVer to automatically set all the Version numbers plus some special BuildMetadata when it is not from the main branch or a release. See parsers/dotnet/Directory.Build.props for more details about it.
* On a release it takes the `VERSION_STATIC` environment variable and overrides any other calculated version number.

I've tested all the GitHub actions in my Fork and even tested the NuGet workflow publish. it perfectly published it to Nuget [Stelzi79.TAML (unlisted!)](https://www.nuget.org/packages/Stelzi79.TAML/)! See also the run of the Workflow on my fork ([publish to nuget](https://github.com/Stelzi79/TAML/actions/runs/275670315)) and the run of the normal build task ([.NET Core](https://github.com/Stelzi79/TAML/actions/runs/275670319))