### PR TITLE
Add missing link to CODE-OF-CONDUCT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The following is a set of guidelines for contributing to the project.  These are
 
 ## Code of Conduct
 
-We have adopted a code of conduct from the Contributor Covenant.  Contributors to this project are expected to adhere to this code.  Please report unwanted behavior to [jeff@jeffreyfritz.com](mailto:jeff@jeffreyfritz.com)
+We have adopted a code of conduct from the [Contributor Covenant](CODE-OF-CONDUCT.md).  Contributors to this project are expected to adhere to this code.  Please report unwanted behavior to [jeff@jeffreyfritz.com](mailto:jeff@jeffreyfritz.com)
 
 ## What should I know before I get started?
 


### PR DESCRIPTION
Add missing link to CODE-OF-CONDUCT.md in the Code of Conduct section